### PR TITLE
Upgrade `jwt` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     jwt_auth (0.1.0)
-      jwt (~> 3.1.2)
+      jwt (~> 3.2)
       rails (>= 7.1, < 9)
 
 GEM
@@ -99,7 +99,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     logger (1.7.0)
     loofah (2.24.1)
@@ -191,6 +191,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   jwt_auth!

--- a/jwt_auth.gemspec
+++ b/jwt_auth.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'rails', '>= 7.1', '< 9'
-  spec.add_dependency 'jwt', '~> 3.1.2'
+  spec.add_dependency 'jwt', '~> 3.2'
 end


### PR DESCRIPTION
# Summary

This PR upgrades the `jwt` gem to 3.2, which includes compatibility fixes for Ruby 4.