### PR TITLE
Fix blank secret key

### DIFF
--- a/jwt_auth.gemspec
+++ b/jwt_auth.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'rails', '>= 7.1', '< 9'
+  spec.add_dependency 'rails', '>= 8.1', '< 9'
   spec.add_dependency 'jwt', '~> 3.2'
 end

--- a/lib/jwt_auth/json_web_token.rb
+++ b/lib/jwt_auth/json_web_token.rb
@@ -2,7 +2,7 @@ require 'jwt'
 
 module JwtAuth
   class JsonWebToken
-    SECRET_KEY = Rails.application.credentials.secret_key_base.to_s
+    SECRET_KEY = Rails.application.secret_key_base
 
     def self.encode(payload)
       JWT.encode(payload, SECRET_KEY)


### PR DESCRIPTION
# Summary

When testing this gem with the updated `jwt` dependency, it was throwing an error because the secret key was empty.

Throwing an error when the secret key is empty was the main breaking change in `jwt` 3.2 from #5, and it turns out that `Rails.application.credentials.secret_key_base.to_s` was returning `nil`. I've replaced that line with the idiomatic `Rails.application.secret_key_base` and it is now correctly reading the secret key and decoding JWTs without any errors.

Just to be safe, I've bumped the Rails version requested by this gem to 8.1, because I'm not sure when the API changed to cause the old value to be `nil` and I'm not sure how far back the new one will work.